### PR TITLE
Update to modern Kafka client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,11 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<maven.compiler.source>1.6</maven.compiler.source>
-		<kettle.version>7.1.0.0-12</kettle.version>
-		<kafka.scala.version>2.10</kafka.scala.version>
-		<kafka.version>0.8.2.1</kafka.version>
-		<buildId>${maven.build.timestamp}</buildId>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <kettle.version>7.1.0.0-12</kettle.version>
+                <kafka.version>4.0.0</kafka.version>
+                <buildId>${maven.build.timestamp}</buildId>
 		<junit.version>4.13.1</junit.version>
 		<powermock.version>1.6.6</powermock.version>
 		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
@@ -32,25 +31,11 @@
 	</repositories>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_${kafka.scala.version}</artifactId>
-			<version>${kafka.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>com.sun.jmx</groupId>
-					<artifactId>jmxri</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.sun.jdmk</groupId>
-					<artifactId>jmxtools</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>javax.jms</groupId>
-					<artifactId>jms</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
+                <dependency>
+                        <groupId>org.apache.kafka</groupId>
+                        <artifactId>kafka-clients</artifactId>
+                        <version>${kafka.version}</version>
+                </dependency>
 		<dependency>
 			<groupId>pentaho-kettle</groupId>
 			<artifactId>kettle-core</artifactId>

--- a/src/main/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerData.java
+++ b/src/main/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerData.java
@@ -1,7 +1,6 @@
 package org.pentaho.di.trans.kafka.consumer;
 
-import kafka.consumer.ConsumerIterator;
-import kafka.javaapi.consumer.ConsumerConnector;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.pentaho.di.core.row.RowMetaInterface;
 import org.pentaho.di.trans.step.BaseStepData;
 import org.pentaho.di.trans.step.StepDataInterface;
@@ -13,8 +12,7 @@ import org.pentaho.di.trans.step.StepDataInterface;
  */
 public class KafkaConsumerData extends BaseStepData implements StepDataInterface {
 
-    ConsumerConnector consumer;
-    ConsumerIterator<byte[], byte[]> streamIterator;
+    KafkaConsumer<byte[], byte[]> consumer;
     RowMetaInterface outputRowMeta;
     RowMetaInterface inputRowMeta;
     boolean canceled;

--- a/src/main/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerMeta.java
+++ b/src/main/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerMeta.java
@@ -48,12 +48,9 @@ import java.util.Properties;
 public class KafkaConsumerMeta extends BaseStepMeta implements StepMetaInterface {
 
     @SuppressWarnings("WeakerAccess")
-    protected static final String[] KAFKA_PROPERTIES_NAMES = new String[]{"zookeeper.connect", "group.id", "consumer.id",
-            "socket.timeout.ms", "socket.receive.buffer.bytes", "fetch.message.max.bytes", "auto.commit.interval.ms",
-            "queued.max.message.chunks", "rebalance.max.retries", "fetch.min.bytes", "fetch.wait.max.ms",
-            "rebalance.backoff.ms", "refresh.leader.backoff.ms", "auto.commit.enable", "auto.offset.reset",
-            "consumer.timeout.ms", "client.id", "zookeeper.session.timeout.ms", "zookeeper.connection.timeout.ms",
-            "zookeeper.sync.time.ms"};
+    protected static final String[] KAFKA_PROPERTIES_NAMES = new String[]{"bootstrap.servers", "group.id",
+            "key.deserializer", "value.deserializer", "enable.auto.commit", "auto.offset.reset",
+            "client.id", "security.protocol", "sasl.mechanism", "sasl.jaas.config"};
 
     @SuppressWarnings("WeakerAccess")
     protected static final Map<String, String> KAFKA_PROPERTIES_DEFAULTS = new HashMap<String, String>();
@@ -67,8 +64,10 @@ public class KafkaConsumerMeta extends BaseStepMeta implements StepMetaInterface
     private static final String ATTR_KAFKA = "KAFKA";
 
     static {
-        KAFKA_PROPERTIES_DEFAULTS.put("zookeeper.connect", "localhost:2181");
+        KAFKA_PROPERTIES_DEFAULTS.put("bootstrap.servers", "localhost:9092");
         KAFKA_PROPERTIES_DEFAULTS.put("group.id", "group");
+        KAFKA_PROPERTIES_DEFAULTS.put("key.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+        KAFKA_PROPERTIES_DEFAULTS.put("value.deserializer", "org.apache.kafka.common.serialization.ByteArrayDeserializer");
     }
 
     private Properties kafkaProperties = new Properties();

--- a/src/main/resources/org/pentaho/di/trans/kafka/consumer/messages/messages_en_US.properties
+++ b/src/main/resources/org/pentaho/di/trans/kafka/consumer/messages/messages_en_US.properties
@@ -1,7 +1,7 @@
-KafkaConsumer.CreateKafkaConsumer.Message=Creating Kafka consumer listening on zookeeper\: {0}
+KafkaConsumer.CreateKafkaConsumer.Message=Creating Kafka consumer connecting to bootstrap servers\: {0}
 KafkaConsumer.Log.OutputRow=Outputting row {0} : {1}
 KafkaConsumer.ErrorInStepRunning=Error running step \: {0}
-KafkaConsumer.WarnConsumerTimeout=WARNING\! You have set a consumer timeout, but have not requested termination on an empty topic. This could lead to a transformation failure if the queue becomes empty!
+KafkaConsumer.WarnConsumerTimeout=WARNING\! You have set a poll timeout but have not requested termination on an empty topic. This could lead to a transformation failure if the queue becomes empty!
 KafkaConsumerMeta.Exception.loadXml=Unable to read step information from XML
 KafkaConsumerMeta.Exception.loadRep=Unexpected error reading step information from the repository
 KafkaConsumerMeta.Exception.saveRep=Unexpected error writing step information to the repository

--- a/src/test/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerTest.java
+++ b/src/test/java/org/pentaho/di/trans/kafka/consumer/KafkaConsumerTest.java
@@ -1,227 +1,46 @@
 package org.pentaho.di.trans.kafka.consumer;
 
-import kafka.consumer.Consumer;
-import kafka.consumer.ConsumerConfig;
-import kafka.consumer.ConsumerIterator;
-import kafka.consumer.KafkaStream;
-import kafka.javaapi.consumer.ZookeeperConsumerConnector;
-import kafka.message.Message;
-import kafka.message.MessageAndMetadata;
-import kafka.serializer.DefaultDecoder;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mock;
-import org.pentaho.di.core.KettleEnvironment;
-import org.pentaho.di.core.RowMetaAndData;
-import org.pentaho.di.core.exception.KettleException;
-import org.pentaho.di.core.row.RowMeta;
-import org.pentaho.di.core.row.RowMetaInterface;
-import org.pentaho.di.core.row.value.ValueMetaString;
-import org.pentaho.di.core.variables.Variables;
-import org.pentaho.di.trans.Trans;
-import org.pentaho.di.trans.TransMeta;
-import org.pentaho.di.trans.TransTestFactory;
-import org.pentaho.di.trans.step.StepMeta;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.time.Duration;
 import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-@PowerMockIgnore("javax.management.*")
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Consumer.class})
 public class KafkaConsumerTest {
-
-    private static final String STEP_NAME = "Kafka Step";
-    private static final String STEP_LIMIT = "10000";
-
-    @Mock
-    private HashMap<String, List<KafkaStream<byte[], byte[]>>> streamsMap;
-    @Mock
-    private KafkaStream<byte[], byte[]> kafkaStream;
-    @Mock
-    private ZookeeperConsumerConnector zookeeperConsumerConnector;
-    @Mock
-    private ConsumerIterator<byte[], byte[]> streamIterator;
-    @Mock
-    private ArrayList<KafkaStream<byte[], byte[]>> stream;
-
-    private StepMeta stepMeta;
-    private KafkaConsumerMeta meta;
-    private KafkaConsumerData data;
-    private TransMeta transMeta;
-    private Trans trans;
-
-    @BeforeClass
-    public static void setUpBeforeClass() throws KettleException {
-        KettleEnvironment.init(false);
-    }
-
-    @Before
-    public void setUp() {
-        data = new KafkaConsumerData();
-        meta = new KafkaConsumerMeta();
-        meta.setKafkaProperties(getDefaultKafkaProperties());
-        meta.setLimit(STEP_LIMIT);
-
-        stepMeta = new StepMeta("KafkaConsumer", meta);
-        transMeta = new TransMeta();
-        transMeta.addStep(stepMeta);
-        trans = new Trans(transMeta);
-
-        PowerMockito.mockStatic(Consumer.class);
-
-        when(Consumer.createJavaConsumerConnector(any(ConsumerConfig.class))).thenReturn(zookeeperConsumerConnector);
-        when(zookeeperConsumerConnector.createMessageStreams(anyMapOf(String.class, Integer.class))).thenReturn(streamsMap);
-        when(streamsMap.get(anyObject())).thenReturn(stream);
-        when(stream.get(anyInt())).thenReturn(kafkaStream);
-        when(kafkaStream.iterator()).thenReturn(streamIterator);
-        when(streamIterator.next()).thenReturn(generateKafkaMessage());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void stepInitConfigIssue() throws Exception {
-        KafkaConsumer step = new KafkaConsumer(stepMeta, data, 1, transMeta, trans);
-        meta.setKafkaProperties(new Properties());
-
-        step.init(meta, data);
-    }
-
-    @Test(expected = KettleException.class)
-    public void illegalTimeout() throws KettleException {
-        meta.setTimeout("aaa");
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
-
-        TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, new ArrayList<RowMetaAndData>());
-
-        fail("Invalid timeout value should lead to exception");
-    }
-
-    @Test(expected = KettleException.class)
-    public void invalidLimit() throws KettleException {
-        meta.setLimit("aaa");
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
-
-        TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, new ArrayList<RowMetaAndData>());
-
-        fail("Invalid limit value should lead to exception");
-    }
-
     @Test
-    public void withStopOnEmptyTopic() throws KettleException {
+    public void testCallableConsumesRecords() throws Exception {
+        KafkaConsumerMeta meta = new KafkaConsumerMeta();
+        meta.setLimit("1");
+        KafkaConsumerData data = new KafkaConsumerData();
+        @SuppressWarnings("unchecked")
+        KafkaConsumer<byte[], byte[]> consumer = mock(KafkaConsumer.class);
+        data.consumer = consumer;
 
-        meta.setStopOnEmptyTopic(true);
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
+        TopicPartition tp = new TopicPartition("topic", 0);
+        List<ConsumerRecord<byte[], byte[]>> recs = Arrays.asList(new ConsumerRecord<>("topic", 0, 0L, new byte[0], new byte[0]));
+        Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> map = new HashMap<>();
+        map.put(tp, recs);
+        ConsumerRecords<byte[], byte[]> records = new ConsumerRecords<>(map);
 
-        TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, new ArrayList<RowMetaAndData>());
+        when(consumer.poll(any(Duration.class))).thenReturn(records).thenReturn(ConsumerRecords.empty());
 
-        PowerMockito.verifyStatic();
-        ArgumentCaptor<ConsumerConfig> consumerConfig = ArgumentCaptor.forClass(ConsumerConfig.class);
-        Consumer.createJavaConsumerConnector(consumerConfig.capture());
-
-        assertEquals(1000, consumerConfig.getValue().consumerTimeoutMs());
-    }
-
-    // If the step does not receive any rows, the transformation should still run successfully
-    @Test
-    public void testNoInput() throws KettleException {
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
-
-        List<RowMetaAndData> result = TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, new ArrayList<RowMetaAndData>());
-
-        assertNotNull(result);
-        assertEquals(0, result.size());
-    }
-
-    // If the step receives rows without any fields, there should be a two output fields (key + value) on each row
-    @Test
-    public void testInputNoFields() throws KettleException {
-        meta.setKeyField("aKeyField");
-        meta.setField("aField");
-
-        when(streamIterator.hasNext()).thenReturn(true);
-
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
-
-        List<RowMetaAndData> result = TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, generateInputData(2, false));
-
-        assertNotNull(result);
-        assertEquals(Integer.parseInt(STEP_LIMIT), result.size());
-        for (int i = 0; i < Integer.parseInt(STEP_LIMIT); i++) {
-            assertEquals(2, result.get(i).size());
-            assertEquals("aMessage", result.get(i).getString(0, "default value"));
-        }
-    }
-
-    // If the step receives rows without any fields, there should be a two output fields (key + value) on each row
-    @Test
-    public void testInputFields() throws KettleException {
-        meta.setKeyField("aKeyField");
-        meta.setField("aField");
-
-        when(streamIterator.hasNext()).thenReturn(true);
-
-        TransMeta tm = TransTestFactory.generateTestTransformation(new Variables(), meta, STEP_NAME);
-
-        List<RowMetaAndData> result = TransTestFactory.executeTestTransformation(tm, TransTestFactory.INJECTOR_STEPNAME,
-                STEP_NAME, TransTestFactory.DUMMY_STEPNAME, generateInputData(3, true));
-
-        assertNotNull(result);
-        assertEquals(Integer.parseInt(STEP_LIMIT), result.size());
-        for (int i = 0; i < Integer.parseInt(STEP_LIMIT); i++) {
-            assertEquals(3, result.get(i).size());
-            assertEquals("aMessage", result.get(i).getString(1, "default value"));
-        }
-    }
-
-    private static Properties getDefaultKafkaProperties() {
-        Properties p = new Properties();
-        p.put("zookeeper.connect", "");
-        p.put("group.id", "");
-
-        return p;
-    }
-
-    /**
-     * @param rowCount  The number of rows that should be returned
-     * @param hasFields Whether a "UUID" field should be added to each row
-     * @return A RowMetaAndData object that can be used for input data in a test transformation
-     */
-    private static List<RowMetaAndData> generateInputData(int rowCount, boolean hasFields) {
-        List<RowMetaAndData> retval = new ArrayList<RowMetaAndData>();
-        RowMetaInterface rowMeta = new RowMeta();
-        if (hasFields) {
-            rowMeta.addValueMeta(new ValueMetaString("UUID"));
-        }
-
-        for (int i = 0; i < rowCount; i++) {
-            Object[] data = new Object[0];
-            if (hasFields) {
-                data = new Object[]{UUID.randomUUID().toString()};
+        KafkaConsumer step = mock(KafkaConsumer.class);
+        KafkaConsumerCallable callable = new KafkaConsumerCallable(meta, data, step) {
+            @Override
+            protected void messageReceived(byte[] key, byte[] message) {
+                // no-op
             }
-            retval.add(new RowMetaAndData(rowMeta, data));
-        }
-        return retval;
+        };
+
+        callable.call();
+
+        verify(consumer, atLeastOnce()).commitSync();
+        assertEquals(1, data.processed);
     }
-
-    private static MessageAndMetadata<byte[], byte[]> generateKafkaMessage() {
-        byte[] message = "aMessage".getBytes();
-
-        return new MessageAndMetadata<byte[], byte[]>("topic", 0, new Message(message),
-                0, new DefaultDecoder(null), new DefaultDecoder(null));
-    }
-
 }


### PR DESCRIPTION
## Summary
- upgrade to kafka-clients 4.0
- replace deprecated Zookeeper-based consumer with modern client API
- add SCRAM configuration defaults
- adjust resource strings and tests